### PR TITLE
Make all errors descend from Protobuf::Error

### DIFF
--- a/lib/protobuf/exceptions.rb
+++ b/lib/protobuf/exceptions.rb
@@ -3,7 +3,7 @@ module Protobuf
   class InvalidWireType < Error; end
   class NotInitializedError < Error; end
   class TagCollisionError < Error; end
-  class SerializationError < StandardError; end
-  class FieldNotDefinedError < StandardError; end
-  class DuplicateFieldNameError < StandardError; end
+  class SerializationError < Error; end
+  class FieldNotDefinedError < Error; end
+  class DuplicateFieldNameError < Error; end
 end


### PR DESCRIPTION
The better to catch all your errors in one place.
