### PR TITLE
Allow Protobuf::Logger to use existing logger

### DIFF
--- a/lib/protobuf/logger.rb
+++ b/lib/protobuf/logger.rb
@@ -14,8 +14,14 @@ module Protobuf
       end
     end
 
-    # One-line file/level configuration
+    # One-line file/level/logger configuration
+    #
+    # @param options [Hash] Hash of options for the logger
+    # @option :logger [::Logger] Logger instance to use underneath.
+    # @option :file [String] File name to log to. Ignored if :logger is specified
+    # @option :level [Logger::Severity] Level to log at. Ignored if :logger is specified
     def self.configure(options)
+      @__instance = options.fetch(:logger, nil)
       self.file = options.fetch(:file, false)
       self.level = options.fetch(:level, false)
     end

--- a/lib/protobuf/logger.rb
+++ b/lib/protobuf/logger.rb
@@ -14,7 +14,8 @@ module Protobuf
       end
     end
 
-    # One-line file/level/logger configuration
+    # One-line file/level/logger configuration. If logger is
+    # specified, file and level are ignored.
     #
     # @param options [Hash] Hash of options for the logger
     # @option :logger [::Logger] Logger instance to use underneath.

--- a/lib/protobuf/version.rb
+++ b/lib/protobuf/version.rb
@@ -1,3 +1,3 @@
 module Protobuf
-  VERSION = '3.2.0'
+  VERSION = '3.3.0'
 end

--- a/protobuffy.gemspec
+++ b/protobuffy.gemspec
@@ -33,5 +33,5 @@ require "protobuf/version"
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'timecop'
-  s.add_development_dependency 'perftools.rb'
+  s.add_development_dependency 'perftools.rb', '~> 2.0.1'
 end

--- a/spec/lib/protobuf/logger_spec.rb
+++ b/spec/lib/protobuf/logger_spec.rb
@@ -52,6 +52,15 @@ describe Protobuf::Logger do
       subject.instance.level.should == ::Logger::WARN
     end
 
+    context 'specifying logger' do
+      let(:logger) { double('Logger') }
+
+      it 'sets the logger instance' do
+        subject.instance.should_not be
+        subject.configure :logger => logger
+        subject.instance.should == logger
+      end
+    end
   end
 
   describe '.reset_device!' do


### PR DESCRIPTION
This allows use of custom loggers and more complex configurations than just setting file and level.