### PR TITLE
Add additional cause for 404 response

### DIFF
--- a/lib/protobuf/rpc/error/server_error.rb
+++ b/lib/protobuf/rpc/error/server_error.rb
@@ -51,5 +51,11 @@ module Protobuf
       end
     end
 
+    class DataNotFound < PbError
+      def initialize message='Requested data not found'
+        super message, 'DATA_NOT_FOUND'
+      end
+    end
+
   end
 end

--- a/lib/protobuf/rpc/servers/http/server.rb
+++ b/lib/protobuf/rpc/servers/http/server.rb
@@ -18,6 +18,7 @@ module Protobuf
           Protobuf::Socketrpc::ErrorReason::FORBIDDEN_REQUEST => 403,
           Protobuf::Socketrpc::ErrorReason::SERVICE_NOT_FOUND => 404,
           Protobuf::Socketrpc::ErrorReason::METHOD_NOT_FOUND => 404,
+          Protobuf::Socketrpc::ErrorReason::DATA_NOT_FOUND => 404,
           Protobuf::Socketrpc::ErrorReason::RPC_ERROR => 500,
           Protobuf::Socketrpc::ErrorReason::RPC_FAILED => 500,
           Protobuf::Socketrpc::ErrorReason::INVALID_REQUEST_PROTO => 500,

--- a/lib/protobuf/version.rb
+++ b/lib/protobuf/version.rb
@@ -1,3 +1,3 @@
 module Protobuf
-  VERSION = '3.4.0'
+  VERSION = '3.5.0'
 end

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -55,6 +55,7 @@ enum ErrorReason
   RPC_FAILED = 5;                               // Rpc failed on server
   UNAUTHORIZED_REQUEST = 10;                    // Server received unauthorized request
   FORBIDDEN_REQUEST = 11;                       // Server understood the request, but is refusing to fulfill it
+  DATA_NOT_FOUND = 12;                          // Requested data not found
 
   // Client-side errors (these are returned by the client-side code)
   INVALID_REQUEST_PROTO = 6;                    // Rpc was called with invalid request proto


### PR DESCRIPTION
SERVICE_NOT_FOUND and METHOD_NOT_FOUND do not represent a case when server cannot find required records. PR adds a constant for data not found case