### PR TITLE
Inject outer environment, bump version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - "1.9.3"
   - "2.3.1"
-script: NO_COMPILE_TEST_PROTOS=1 bundle exec rake spec/lib
+script: gem install bundler -v 1.12.5 && NO_COMPILE_TEST_PROTOS=1 bundle _1.12.5_ exec rake spec/lib
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: ruby
 rvm:
   - "1.9.3"
   - "2.3.1"
-script: gem install bundler -v 1.12.5 && NO_COMPILE_TEST_PROTOS=1 bundle _1.12.5_ exec rake spec/lib
+before_install:
+  - gem install bundler
+script: NO_COMPILE_TEST_PROTOS=1 bundle _1.12.5_ exec rake spec/lib
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - "1.9.3"
-  - "2.0.0"
+  - "2.3.1"
 script: NO_COMPILE_TEST_PROTOS=1 bundle exec rake spec/lib
 notifications:
   webhooks:

--- a/lib/protobuf/rpc/env.rb
+++ b/lib/protobuf/rpc/env.rb
@@ -39,6 +39,7 @@ module Protobuf
                     :encoded_response,
                     :log_signature,
                     :method_name,
+                    :parent_env,
                     :request,
                     :request_type,
                     :response,

--- a/lib/protobuf/rpc/server.rb
+++ b/lib/protobuf/rpc/server.rb
@@ -20,10 +20,12 @@ module Protobuf
 
       # Invoke the service method dictated by the proto wrapper request object
       #
-      def handle_request(request_data)
+      def handle_request(request_data, parent_env = nil)
         # Create an env object that holds different parts of the environment and
         # is available to all of the middlewares
-        env = Env.new('encoded_request' => request_data, 'log_signature' => log_signature)
+        env = Env.new('encoded_request' => request_data,
+                      'log_signature' => log_signature,
+                      'parent_env' => parent_env)
 
         # Invoke the middleware stack, the last of which is the service dispatcher
         env = Rpc.middleware.call(env)

--- a/lib/protobuf/rpc/servers/http/server.rb
+++ b/lib/protobuf/rpc/servers/http/server.rb
@@ -56,7 +56,7 @@ module Protobuf
           encoded_request = rpc_request.encode()
 
           begin
-            encoded_response = handle_request(encoded_request)
+            encoded_response = handle_request(encoded_request, env)
           rescue Exception => e
             return protobuf_http_response 500,
               :error => "Handle request failed: #{e.to_s}",

--- a/lib/protobuf/version.rb
+++ b/lib/protobuf/version.rb
@@ -1,3 +1,3 @@
 module Protobuf
-  VERSION = '3.5.1'
+  VERSION = '3.6.0'
 end

--- a/protobuffy.gemspec
+++ b/protobuffy.gemspec
@@ -19,13 +19,18 @@ require "protobuf/version"
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'activesupport', '~> 3.2'
+  if RUBY_VERSION =~ /^2/
+    s.add_dependency 'activesupport'
+  else
+    s.add_dependency 'activesupport', '< 5'
+  end
+
   s.add_dependency 'middleware'
   s.add_dependency 'multi_json', '~> 1.0'
   s.add_dependency 'thor'
   s.add_dependency 'json', '< 2.0'
 
-  s.add_development_dependency 'rack', '< 1.99'
+  s.add_development_dependency 'rack', '~> 1.0'
   s.add_development_dependency 'faraday'
   s.add_development_dependency 'ffi-rzmq'
   s.add_development_dependency 'pry-nav'

--- a/protobuffy.gemspec
+++ b/protobuffy.gemspec
@@ -19,12 +19,13 @@ require "protobuf/version"
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'activesupport', '>= 3.2'
+  s.add_dependency 'activesupport', '~> 3.2'
   s.add_dependency 'middleware'
-  s.add_dependency 'multi_json'
+  s.add_dependency 'multi_json', '~> 1.0'
   s.add_dependency 'thor'
+  s.add_dependency 'json', '< 2.0'
 
-  s.add_development_dependency 'rack'
+  s.add_development_dependency 'rack', '< 1.99'
   s.add_development_dependency 'faraday'
   s.add_development_dependency 'ffi-rzmq'
   s.add_development_dependency 'pry-nav'


### PR DESCRIPTION
Version 3.6 introduces a backwards-compatible change to access the outer environment of the request.

Now, service can invoke `@env.parent_env` and access any header that was not particularly prescribed by Protobuf::Rpc::Env.

This means that we can inspect auth headers and additional claimsets on the fly.

In particular, for token-based authenticated RPC requests, we can extract the claims and use them to drive the logic associated with the request.