### PR TITLE
Update deprecated method alias_method_chain

### DIFF
--- a/lib/protobuf/code_generator.rb
+++ b/lib/protobuf/code_generator.rb
@@ -86,7 +86,8 @@ module Protobuf
         end
       end
 
-      alias_method_chain :set, :options
+      alias_method :set_without_options, :set
+      alias_method :set, :set_with_options
     end
   end
 end

--- a/lib/protobuf/version.rb
+++ b/lib/protobuf/version.rb
@@ -1,3 +1,3 @@
 module Protobuf
-  VERSION = '4.0.0'.freeze
+  VERSION = '4.0.1'.freeze
 end

--- a/protobuffy.gemspec
+++ b/protobuffy.gemspec
@@ -26,7 +26,7 @@ require "protobuf/version"
   s.add_dependency 'thor'
   s.add_dependency 'thread_safe'
 
-  s.add_development_dependency 'ffi-rzmq'
+  s.add_development_dependency 'ffi-rzmq', '<= 2.0.4'
   s.add_development_dependency 'rake', '< 11.0' # Rake 11.0.1 removes the last_comment method which rspec-core (< 3.4.4) uses
   s.add_development_dependency 'rack', '~> 1.0'
   s.add_development_dependency 'faraday'


### PR DESCRIPTION
ActiveSupport 5.1 came out and removed :alias_method_chain
which was used in the code generator. This replaces it with the fix
that was used in the upstream branch.

https://github.com/ruby-protobuf/protobuf/pull/368/commits/45aaa05c7790d1d4d0eac46f189aafb47b48f9cc

JIRA: LB-13695