### PR TITLE
Allow empty protobufs in decoding

### DIFF
--- a/lib/protobuf/rpc/middleware/request_decoder.rb
+++ b/lib/protobuf/rpc/middleware/request_decoder.rb
@@ -46,7 +46,6 @@ module Protobuf
         end
 
         def request
-          fail if request_wrapper.request_proto.blank?
           @request ||= rpc_method.request_type.decode(request_wrapper.request_proto)
         rescue => exception
           raise BadRequestData, "Unable to decode request: #{exception.message}"

--- a/spec/lib/protobuf/rpc/servers/http/server_spec.rb
+++ b/spec/lib/protobuf/rpc/servers/http/server_spec.rb
@@ -74,12 +74,13 @@ describe Protobuf::Rpc::Http::Server do
       expect(response.body).to eq ""
     end
 
-    it 'should return RPC_FAILED for missing input' do
+    it 'should not return RPC_FAILED for missing input' do
       response = client.post "/ReverseModule%3A%3AReverseService/reverse", :input => ""
-      expect(response.status).to eq 400
+      expect(response.status).to eq 200
       expect(response.headers['content-type']).to eq "application/x-protobuf"
-      expect(response.headers['x-protobuf-error-reason']).to eq Protobuf::Socketrpc::ErrorReason::BAD_REQUEST_DATA.to_s
-      expect(response.body).to eq ""
+      expect(response.headers['x-protobuf-error']).to be_nil
+      expect(response.headers['x-protobuf-error-reason']).to be_nil
+      expect(response.body).to eq ReverseModule::ReverseResponse.new(:reversed => "".reverse).encode
     end
 
     it 'should return RPC_ERROR for invalid input' do


### PR DESCRIPTION
In device config, we have one RPC that takes an
empty message since the params are handled by keymaster.
This breaks in decoding since protobuffy is checking to
see if it's blank. This removes that check.

JIRA: LB-14341